### PR TITLE
Fixed assurance activity grouping for FCS_COP.1.1(1).

### DIFF
--- a/input/application.xml
+++ b/input/application.xml
@@ -1554,11 +1554,11 @@ functionality (such as these)
                 key value of all zeros with an IV of all zeros, respectively.
                 Plaintext value i in each set shall have the leftmost i bits be
                 ones and the rightmost 128-i bits be zeros, for i in
-                [1,128].</h:li>
-              </h:ul>To test the decrypt functionality of AES-CBC, the evaluator
-              shall perform the same test as for encrypt, using ciphertext values
-              of the same form as the plaintext in the encrypt test as input and
-              AES-CBC decryption. 
+                [1,128]. To test the decrypt functionality of AES-CBC, the
+                evaluator shall perform the same test as for encrypt, using
+                ciphertext values of the same form as the plaintext in the
+                encrypt test as input and AES-CBC decryption.</h:li>
+              </h:ul> 
               <h:br />
               <h:b>AES-CBC Multi-Block Message Test</h:b>
               <h:p />The evaluator shall test the encrypt functionality by
@@ -1574,12 +1574,14 @@ functionality (such as these)
               decrypt the message, using the mode to be tested, with the chosen
               key and IV. The plaintext shall be compared to the result of
               decrypting the same ciphertext message with the same key and IV
-              using a known good implementation. AES-CBC Monte Carlo Tests The
-              evaluator shall test the encrypt functionality using a set of 200
-              plaintext, IV, and key 3- tuples. 100 of these shall use 128 bit
-              keys, and 100 shall use 256 bit keys. The plaintext and IV values
-              shall be 128-bit blocks. For each 3-tuple, 1000 iterations shall be
-              run as follows: 
+              using a known good implementation.
+              <h:br />
+              <h:b>AES-CBC Monte Carlo Tests</h:b>
+              <h:p />The evaluator shall test the encrypt functionality using a
+              set of 200 plaintext, IV, and key 3- tuples. 100 of these shall
+              use 128 bit keys, and 100 shall use 256 bit keys. The plaintext
+              and IV values shall be 128-bit blocks. For each 3-tuple, 1000
+              iterations shall be run as follows: 
               <h:pre>
               # Input: PT, IV, Key
               for i = 1 to 1000:


### PR DESCRIPTION
- Moved the AES-CBC decrypt step to be part of KAT-4. This matches the
  structure used in the other known answer tests.
- Made AES-CBC Monte Carlo Tests its own heading.
